### PR TITLE
: Cambio de Idioma Total de Inglés a Japonés

### DIFF
--- a/issues daniel/index2.html
+++ b/issues daniel/index2.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
-
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Anime Website</title>
+    <title>アニメウェブサイト</title>
     <style>
         body {
             margin: 0;
@@ -100,44 +99,41 @@
         }
     </style>
 </head>
-
 <body>
     <header>
-        <h1>Welcome to the Anime World</h1>
+        <h1>アニメの世界へようこそ</h1>
         <nav>
             <ul>
-                <li><a href="#">Home</a></li>
-                <li><a href="#">Anime Series</a></li>
-                <li><a href="#">Manga</a></li>
-                <li><a href="#">News</a></li>
-                <li><a href="#">Contact</a></li>
+                <li><a href="#">ホーム</a></li>
+                <li><a href="#">アニメシリーズ</a></li>
+                <li><a href="#">マンガ</a></li>
+                <li><a href="#">ニュース</a></li>
+                <li><a href="#">お問い合わせ</a></li>
             </ul>
         </nav>
     </header>
 
     <main>
         <section class="featured-anime">
-            <h2>Featured Anime</h2>
+            <h2>注目のアニメ</h2>
             <div class="anime-info">
-                <img src="https://es.web.img2.acsta.net/c_310_420/pictures/16/02/03/17/11/571106.jpg" alt="Anime Image">
+                <img src="https://es.web.img2.acsta.net/c_310_420/pictures/16/02/03/17/11/571106.jpg" alt="アニメ画像">
                 <div class="anime-details">
-                    <h3>Anime Title</h3>
-                    <p>Genres: Acción,Aventuras,Comedia,Drama,Fantasía,Shounen,Superpoderes</p>
-                    <p>Description: Una historia épica de piratas, donde narra la historia de "Monkey D. Luffy" quien cuado tenia 7 años, comió accidentalmente una "Akuma no mi"(Futa del diablo) la cual le dio poderes de goma. Por otra parte "Gol D. Roger" conocido como "El rey de los Piratas" quien fuera ejecutado por la Marine, habló antes de morir, acerca de su famoso tesoro "One Piece" escondido en la "Gran line". Esta noticia desato la gran era de la piratas lanzando a incontables piratas a ese lugar, en busca de "One Piece" el tesoro perdido. Diez años después, Luffy inspirado en "Gol D. Roger" y un pirata de nombre Akagami no Shanks (Shanks el pelirrojo) se convierte en pirata deseando ser el próximo "Rey de los Piratas" y zarpar para conocer amigos y tener aventuras con ellos, teniendo como meta encontrar el "One Piece".
-                    </p>
+                    <h3>アニメのタイトル</h3>
+                    <p>ジャンル: アクション、冒険、コメディ、ドラマ、ファンタジー、少年、スーパーパワー</p>
+                    <p>説明: ゴムの能力を持つ "Monkey D. Luffy" が、7歳のときに「Akuma no mi」（悪魔の実）を誤って食べ、ゴムの力を手に入れた。一方、「Gol D. Roger」は「海軍」によって処刑される前に、彼の有名なお宝「ワンピース」が「グランライン」に隠されていると話しました。このニュースは、失われたお宝「ワンピース」を探して無数の海賊をこの場所に送り、大きな海賊の時代を引き起こしました。10年後、Luffyは「Gol D. Roger」に触発され、「赤髪のシャンクス」（Shanks el pelirrojo）という名の海賊と一緒に冒険仲間を見つけ、友達と冒険をし、次の「海賊の王」になることを望んで出航しました。</p>
                 </div>
             </div>
         </section>
 
         <section class="latest-news">
-            <h2>Latest News</h2>
-            <!-- Aquí puedes agregar noticias sobre anime -->
+            <h2>最新ニュース</h2>
+            <!-- ここにアニメに関するニュースを追加できます -->
         </section>
     </main>
 
     <footer>
-        <p>&copy; 2023 Anime Website. All rights reserved.</p>
+        <p>&copy; 2023 アニメウェブサイト。全著作権所有。</p>
     </footer>
 </body>
-
 </html>


### PR DESCRIPTION
se cambio el idioma total del sitio web al japonés. Los cambios incluyen:

- Traducción completa del contenido al japonés.
- Actualización de etiquetas de texto, títulos y descripciones en japonés.
- Eliminación de la opción de cambiar a inglés, enfocándonos exclusivamente en el idioma japonés.

Esta implementación busca brindar una experiencia de usuario mejorada para nuestros visitantes japoneses, permitiéndoles acceder a nuestro contenido en su idioma nativo.